### PR TITLE
Add did:web method entry

### DIFF
--- a/registry/method_did_web.md
+++ b/registry/method_did_web.md
@@ -1,0 +1,20 @@
+### did:web AnonCreds Method
+
+This method defines a common way of referencing and resolving AnonCreds objects
+based on the security provided by [did:web](https://w3c-ccg.github.io/did-method-web/)
+specification, where resources can be stored and accessed by simply using web servers 
+and traditional databases.
+
+It inherits the same advantages and drawbacks from did:web, such as the simplicity 
+(which might be useful to encourage the adoption of AnonCreds) and the lack of 
+decentralisation that a blockchain or DLT-based method can provide.
+
+It does not enforce any particular API or implementation for object creation or 
+storage, other than a few measures to ensure object immutability.
+
+- Status: In Development
+- Verifiable Data Registry: did:web
+- Contact Name: Ariel Gentile / Patrick St-Louis
+- Contact Email: a@2060.io / patrick.st-louis@idlab.org
+- Contact Website: [https://github.com/2060-io/did-web-anoncreds-method](https://github.com/2060-io/did-web-anoncreds-method)
+- Specification: To Be Added

--- a/specs.json
+++ b/specs.json
@@ -11,6 +11,7 @@
         "registry.md",
         "method_legacy_indy.md",
         "method_did_indy.md",
+        "method_did_web.md",
         "method_http.md",
         "method_cheqd.md",
         "method_cardano.md",


### PR DESCRIPTION
Adding an entry for the did:web AnonCreds Method, based on the development being done by 2060.io and Digital Identity Lab of Canada.